### PR TITLE
Fix preview deployments

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -416,6 +416,7 @@ jobs:
           projectName: buddy
           directory: build/renderer
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref || github.ref_name }}
 
       - name: Comment preview URL
         uses: thollander/actions-comment-pull-request@v2


### PR DESCRIPTION
As it appears right now, preview deployments (from any PR) are being deployed to the main Buddy site, as the `branch` attribute is set with `master` regardless.