### PR TITLE
fix: hide unused menu bar on Linux and Windows builds

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,7 @@ const createWindow = (): void => {
     titleBarStyle: "hidden",
     resizable: !config.isProduction,
     show: false,
+    autoHideMenuBar: true,
     webPreferences: {
       allowRunningInsecureContent: false,
       // Need these enabled when e2e is running
@@ -69,6 +70,8 @@ const createWindow = (): void => {
       preload: `${__dirname}/preload.js`,
     } as electron.WebPreferences,
   });
+
+  if (config.isProduction) mainWindow.setMenu(null);
 
   if (config.startParams.isE2e) {
     session


### PR DESCRIPTION
Menu bar is populated by default on Windows and Linux Electron builds even when not used.

This makes it so it is auto-hidden on dev builds (so it's still accessible if wanted), but fully disabled on "production" builds.