### PR TITLE
feat: add link to DFU mode manual page

### DIFF
--- a/locales/be/flashing.json
+++ b/locales/be/flashing.json
@@ -61,6 +61,7 @@
   "Flashing done": "Перапрашыўка завершана",
   "Flashing EdgeTX": "Прашыўка EdgeTX",
   "Go back": "Назад",
+  "How to access DFU for your handset": "Як атрымаць доступ да DFU для вашага апарата",
   "Include pre-releases": "Уключаць прэ-рэлізы",
   "Loading commits...": "Загрузка коммітаў...",
   "Loading pull requests...": "Загрузка запытаў на абнаўленне...",

--- a/locales/cs/flashing.json
+++ b/locales/cs/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Zapisování dokončeno",
   "Flashing EdgeTX": "Zapisování EdgeTX",
   "Go back": "Zpět",
+  "How to access DFU for your handset": "Jak přistupovat k DFU pro váš přístroj",
   "In queue": "In queue",
   "Include pre-releases": "Include pre-releases",
   "Loading commits...": "Stahuji commity...",

--- a/locales/da/flashing.json
+++ b/locales/da/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Brænding klar",
   "Flashing EdgeTX": "Brænder EdgeTX image",
   "Go back": "Tilbage",
+  "How to access DFU for your handset": "Sådan får du adgang til DFU for din håndholdte enhed",
   "In queue": "In queue",
   "Include pre-releases": "Medtag udviklings versioner",
   "Loading commits...": "Indlæser git commits...",

--- a/locales/de/flashing.json
+++ b/locales/de/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Flashen fertig",
   "Flashing EdgeTX": "Flashe EdgeTX",
   "Go back": "Zurück",
+  "How to access DFU for your handset": "So greifen Sie auf den DFU-Modus für Ihr Gerät zu",
   "In queue": "In queue",
   "Include pre-releases": "Vorabversionen einbeziehen",
   "Loading commits...": "Commits werden geladen...",

--- a/locales/es/flashing.json
+++ b/locales/es/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Flashing done",
   "Flashing EdgeTX": "Flashing EdgeTX",
   "Go back": "Go back",
+  "How to access DFU for your handset": "Cómo acceder al modo DFU para tu dispositivo",
   "In queue": "In queue",
   "Include pre-releases": "Include pre-releases",
   "Loading commits...": "Loading commits...",

--- a/locales/fr/flashing.json
+++ b/locales/fr/flashing.json
@@ -61,6 +61,7 @@
   "Flashing done": "Flashing done",
   "Flashing EdgeTX": "Flashing EdgeTX",
   "Go back": "Go back",
+  "How to access DFU for your handset": "Comment accéder au mode DFU pour votre appareil",
   "Include pre-releases": "Include pre-releases",
   "Loading commits...": "Loading commits...",
   "Loading pull requests...": "Loading pull requests...",

--- a/locales/it/flashing.json
+++ b/locales/it/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Flash completato",
   "Flashing EdgeTX": "Flash di EdgeTX",
   "Go back": "Torna",
+  "How to access DFU for your handset": "Come accedere alla DFU per il tuo dispositivo",
   "In queue": "In queue",
   "Include pre-releases": "Includi le pre-releases",
   "Loading commits...": "Carico i commit...",

--- a/locales/ru/flashing.json
+++ b/locales/ru/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Перепрошивка завершена",
   "Flashing EdgeTX": "Прошивка EdgeTX",
   "Go back": "Назад",
+  "How to access DFU for your handset": "Как получить доступ к DFU для вашего аппарата",
   "In queue": "In queue",
   "Include pre-releases": "Включать пре-релизы",
   "Loading commits...": "Загрузка коммитов...",

--- a/locales/sv/flashing.json
+++ b/locales/sv/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "Flashning klar",
   "Flashing EdgeTX": "Flashar EdgeTX",
   "Go back": "Tillbaka",
+  "How to access DFU for your handset": "Hur man får tillgång till DFU för din handenhet",
   "In queue": "I kö",
   "Include pre-releases": "Inkludera utvecklingsversioner",
   "Loading commits...": "Läser in git commits...",

--- a/locales/zh/flashing.json
+++ b/locales/zh/flashing.json
@@ -65,6 +65,7 @@
   "Flashing done": "刷写完成",
   "Flashing EdgeTX": "正在刷写 EdgeTX",
   "Go back": "返回",
+  "How to access DFU for your handset": "如何为您的手持设备访问DFU",
   "In queue": "In queue",
   "Include pre-releases": "包括预发布版本",
   "Loading commits...": "正在加载 commits...",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -62,6 +62,7 @@ const createWindow = (): void => {
     titleBarStyle: "hidden",
     resizable: !config.isProduction,
     show: false,
+    autoHideMenuBar: true,
     webPreferences: {
       allowRunningInsecureContent: false,
       // Need these enabled when e2e is running
@@ -69,6 +70,8 @@ const createWindow = (): void => {
       preload: `${__dirname}/preload.js`,
     } as electron.WebPreferences,
   });
+
+  if (config.isProduction) mainWindow.setMenu(null);
 
   if (config.startParams.isE2e) {
     session

--- a/src/renderer/components/devices/DeviceSelector.tsx
+++ b/src/renderer/components/devices/DeviceSelector.tsx
@@ -6,7 +6,7 @@ import {
 import { gql, useMutation, useQuery } from "@apollo/client";
 import { Button, Card, Empty, Typography } from "antd";
 import React, { useEffect } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import useIsMobile from "renderer/hooks/useIsMobile";
 import { Centered } from "renderer/shared/layouts";
 import styled from "styled-components";
@@ -152,9 +152,21 @@ const DeviceSelector: React.FC<Props> = ({
                 />
               }
               description={
-                variant === "electron"
-                  ? t(`No devices found`)
-                  : t(`Add a device to get started`)
+                variant === "electron" ? (
+                  t(`No devices found`)
+                ) : (
+                  <Trans t={t}>
+                    Add a device to get started
+                    <br />
+                    <a
+                      target="_blank"
+                      href="https://manual.edgetx.org/edgetx-how-to/access-dfu-and-bootloader-mode"
+                      rel="noreferrer"
+                    >
+                      How to access DFU for your handset
+                    </a>
+                  </Trans>
+                )
               }
             >
               {actionButton}


### PR DESCRIPTION
Resolves #52

Adds a link to the DFU/bootloader mode page on the EdgeTX Manual on the "Connect radio" stage of the USB flashing process. With translations thanks to GitHub copilot.

![image](https://github.com/EdgeTX/buddy/assets/5500713/5b2cf446-6305-4586-be60-a54e3370018a)
