### PR TITLE
chore(ci): bump action versions, python for macosx

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,7 +74,7 @@ jobs:
           CI: true
 
       - name: Publish Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
 
   test-types:
     runs-on: ubuntu-latest
@@ -121,7 +121,7 @@ jobs:
         run: yarn build:storybook
 
       - name: Store storybook
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: storybook-static
           retention-days: 1
@@ -165,7 +165,7 @@ jobs:
           GITHUB_PR_BUILDS_KEY: ${{ secrets.PR_BUILDS_TOKEN }}
 
       - name: Store compiled source
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: compiled-${{ matrix.os }}
           retention-days: 1
@@ -210,7 +210,7 @@ jobs:
         run: yarn run pack
 
       - name: Upload build
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-builds
           retention-days: 15
@@ -240,14 +240,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: electron-${{ matrix.os }}-test-results
           path: playwright-report
 
       - name: Upload video recordings
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: electron-${{ matrix.os }}-recordings

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Publish Coverage
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-types:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -339,21 +339,19 @@ jobs:
 
       - name: Preview
         id: cloudflare-preview
-        uses: cloudflare/pages-action@1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: buddy
-          directory: build/renderer
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.head_ref || github.ref_name }}
+          workingDirectory: build/renderer
+          command: pages deploy --project-name=buddy
 
       - name: Comment preview URL
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
             EdgeTX Buddy has been automatically deployed to Cloudflare.
-            ✅ Preview: ${{ steps.cloudflare-preview.outputs.url }}
+            ✅ Preview: ${{ steps.cloudflare-preview.outputs.deployment-url }}
             ✅ Storybook: ${{ steps.cloudflare-preview.outputs.url }}/storybook
 
   release-web-prod:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -349,9 +349,9 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            _(preview_urls EdgeTX Buddy has been automatically deployed to Cloudflare.
+            preview_urls EdgeTX Buddy has been automatically deployed to Cloudflare.
             ✅ Preview: ${{ steps.cloudflare-preview.outputs.deployment-url }}
-            ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook)_
+            ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook
             comment_tag: preview_urls
 
   release-web-prod:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -352,7 +352,7 @@ jobs:
             preview_urls EdgeTX Buddy has been automatically deployed to Cloudflare.
             ✅ Preview: ${{ steps.cloudflare-preview.outputs.deployment-url }}
             ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook
-            comment_tag: preview_urls
+          comment_tag: preview_urls
 
   release-web-prod:
     needs: [e2e-web, test, storybook]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -337,7 +337,7 @@ jobs:
           name: storybook-static
           path: build/renderer/storybook
 
-      - name: Preview
+      - name: Deploy preview
         id: cloudflare-preview
         uses: cloudflare/wrangler-action@v3
         with:
@@ -345,14 +345,24 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy build/renderer --project-name=buddy
 
-      - name: Comment preview URL
-        uses: thollander/actions-comment-pull-request@v2
+      - name: Find preview comment if present
+        uses: peter-evans/find-comment@v3
+        id: find-preview-comment
         with:
-          message: |
-            preview_urls EdgeTX Buddy has been automatically deployed to Cloudflare.
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Buddy has been automatically deployed to Cloudflare
+
+      - name: Create or update preview URL comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-preview-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            EdgeTX Buddy has been automatically deployed to Cloudflare.
             ✅ Preview: ${{ steps.cloudflare-preview.outputs.deployment-url }}
             ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook
-          comment_tag: preview_urls
+          edit-mode: replace
 
   release-web-prod:
     needs: [e2e-web, test, storybook]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -145,6 +145,11 @@ jobs:
           node-version: "20"
           cache: "yarn"
 
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
       - name: Install required python deps
         run: python3 -m pip install setuptools
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -351,7 +351,7 @@ jobs:
           message: |
             EdgeTX Buddy has been automatically deployed to Cloudflare.
             ✅ Preview: ${{ steps.cloudflare-preview.outputs.deployment-url }}
-            ✅ Storybook: ${{ steps.cloudflare-preview.outputs.url }}/storybook
+            ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook
 
   release-web-prod:
     needs: [e2e-web, test, storybook]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -206,7 +206,7 @@ jobs:
         run: yarn --immutable
 
       - name: Fetch compiled source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compiled-${{ matrix.os }}
           path: build
@@ -300,7 +300,7 @@ jobs:
         run: yarn playwright install --with-deps
 
       - name: Fetch compiled source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compiled-ubuntu-20.04
           path: build
@@ -312,7 +312,7 @@ jobs:
           PWTEST_VIDEO: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: video-web-linux-test-results
@@ -324,13 +324,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch compiled source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compiled-ubuntu-20.04
           path: build
 
       - name: Fetch storybook build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: storybook-static
           path: build/renderer/storybook
@@ -360,7 +360,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Fetch compiled source
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: compiled-ubuntu-20.04
           path: build
@@ -380,7 +380,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Fetch binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: app-builds
           path: app-builds

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -349,9 +349,10 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            EdgeTX Buddy has been automatically deployed to Cloudflare.
+            _(preview_urls EdgeTX Buddy has been automatically deployed to Cloudflare.
             ✅ Preview: ${{ steps.cloudflare-preview.outputs.deployment-url }}
-            ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook
+            ✅ Storybook: ${{ steps.cloudflare-preview.outputs.deployment-url }}/storybook)_
+            comment_tag: preview_urls
 
   release-web-prod:
     needs: [e2e-web, test, storybook]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -343,8 +343,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: build/renderer
-          command: pages deploy --project-name=buddy
+          command: pages deploy build/renderer --project-name=buddy
 
       - name: Comment preview URL
         uses: thollander/actions-comment-pull-request@v2

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -217,7 +217,7 @@ jobs:
       - name: Upload build
         uses: actions/upload-artifact@v4
         with:
-          name: app-builds
+          name: app-builds-${{ matrix.os }}
           retention-days: 15
           if-no-files-found: error
           path: |
@@ -382,8 +382,9 @@ jobs:
       - name: Fetch binaries
         uses: actions/download-artifact@v4
         with:
-          name: app-builds
+          pattern: app-builds-*
           path: app-builds
+          merge-multiple: true
 
       - name: Release latest build
         if: startsWith(github.ref, 'refs/tags/v') != true


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

- codecov/codecov-action@v2
- actions/upload-artifact@v3

The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "compiled-ubuntu-20.04", "compiled-windows-latest", "storybook-static".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

- actions/upload-artifact@v3

Code Coverage has been needing a token for the last three months, so the failure is expected. 

cloudflare/pages-action@v1 is still using NodeJS v16, and there has not been any updates to it. Given the lack of movement of https://github.com/cloudflare/pages-action/issues/117, and PRs that fix this, it is probably worth moving to https://github.com/cloudflare/wrangler-action as this *is* being (more) actively maintained. **DONE**

I also updated the link preview step to edit the message in place, so there should only be one comment from in a PR. Because it edits rather than deletes and replaces comment, prior links can be access that way if needed. 