### PR TITLE
feat: improve flashing speed

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -325,6 +325,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Fetch compiled source
         uses: actions/download-artifact@v4
         with:

--- a/e2e/pages/firmware-wizard/firmware-selection.spec.ts
+++ b/e2e/pages/firmware-wizard/firmware-selection.spec.ts
@@ -160,7 +160,9 @@ test("Copy URL button copies a link to the selected firmware", async ({
   test.skip(browserName !== "chromium");
   await (await queries.findByLabelText("Firmware version")).press("Enter");
   await page
-    .locator(".ant-select-item-option[title='EdgeTX \"Santa\" v2.6.0']")
+    .locator(
+      ".ant-select-item-option[title='EdgeTX \"Flying Dutchman\" v2.8.5']"
+    )
     .click();
 
   const radioSelector = await queries.findByLabelText("Radio model");
@@ -181,9 +183,9 @@ test("Copy URL button copies a link to the selected firmware", async ({
 
   if (isElectron) {
     expect(copiedUrl).toBe(
-      "buddy.edgetx.org/#/flash?version=v2.6.0&target=x10"
+      "buddy.edgetx.org/#/flash?version=v2.8.5&target=x10"
     );
   } else {
-    expect(copiedUrl).toBe("localhost:8081/#/flash?version=v2.6.0&target=x10");
+    expect(copiedUrl).toBe("localhost:8081/#/flash?version=v2.8.5&target=x10");
   }
 });

--- a/src/shared/dfu/index.ts
+++ b/src/shared/dfu/index.ts
@@ -635,9 +635,12 @@ export class WebDFU {
       (ignoreErrors || dfuStatus.state !== dfuCommands.dfuERROR)
     ) {
       // eslint-disable-next-line no-await-in-loop
-      await asyncSleep(dfuStatus.pollTimeout);
-      // eslint-disable-next-line no-await-in-loop
-      dfuStatus = await this.getStatus();
+      await asyncSleep(0);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        dfuStatus = await this.getStatus();
+        // eslint-disable-next-line no-empty
+      } catch (error) {}
     }
 
     return dfuStatus;


### PR DESCRIPTION
This PR improves the flashing speed by ignoring the `pollTimeout` returned by ST's DFU bootloader, which is way too long and just polls the status continuously. 